### PR TITLE
fix name of chrony package for macOS

### DIFF
--- a/playbooks/install_prerequisites.yaml
+++ b/playbooks/install_prerequisites.yaml
@@ -58,9 +58,9 @@
         tasks_from: install_on_linux
       when:
         - ansible_facts.system == 'Linux'
-    - name: Install chronyc on macOS
+    - name: Install chrony on macOS
       vars:
-        package_name: chronyc
+        package_name: chrony
       ansible.builtin.include_role:
         name: hyperledger.fabricx.package
         tasks_from: install_on_macos


### PR DESCRIPTION
The brew formula is found under chrony: https://formulae.brew.sh/formula/chrony