### PR TITLE
add option to use a docker or podman network

### DIFF
--- a/roles/container/tasks/docker/start.yaml
+++ b/roles/container/tasks/docker/start.yaml
@@ -4,13 +4,21 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+- name: Create docker network
+  community.docker.docker_network:
+    name: "{{ container_network_name }}"
+    driver: "{{ container_network_driver | default('bridge') }}"
+    state: present
+  when: container_network_name is defined
+
 - name: Start docker container with image {{ container_image }}
   community.docker.docker_container:
     name: "{{ container_name }}"
     image: "{{ container_image }}"
     entrypoint: "{{ container_entrypoint }}"
     command: "{{ container_command }}"
-    network_mode: "{{ container_network_mode }}"
+    networks: "{{ [{'name': container_network_name}] if container_network_name is defined else omit }}"
+    network_mode: "{{ (container_network_name is not defined) | ternary(container_network_mode | default(omit), omit) }}"
     ports: "{{ container_ports if container_network_mode == 'bridge' else [] }}"
     memory: "{{ container_memory }}"
     volumes: "{{ container_volumes }}"

--- a/roles/container/tasks/podman/start.yaml
+++ b/roles/container/tasks/podman/start.yaml
@@ -4,13 +4,27 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+- name: Check if network exists
+  command: podman network inspect {{ container_network_name }}
+  register: podman_network_inspect
+  failed_when: false
+  changed_when: false
+  when: container_network_name is defined and container_network_name is not none
+
+- name: Create podman network
+  containers.podman.podman_network:
+    name: "{{ container_network_name }}"
+    driver: "{{ container_network_driver | default('bridge') }}"
+    state: present
+  when: container_network_name is defined and container_network_name is not none and podman_network_inspect.rc != 0
+
 - name: Start podman container with image {{ container_image }}
   containers.podman.podman_container:
     name: "{{ container_name }}"
     image: "{{ container_image }}"
     entrypoint: "{{ container_entrypoint }}"
     command: "{{ container_command }}"
-    network: "{{ container_network_mode }}"
+    network: "{{ container_network_name | default(container_network_mode, true) | default(omit, true) }}"
     ports: "{{ container_ports if container_network_mode == 'bridge' else [] }}"
     memory: "{{ container_memory }}"
     volumes: "{{ container_volumes }}"


### PR DESCRIPTION
This PR adds the ability to attach to an existing or to create a new docker or podman network by specifying `container_network_name`. It defaults to the `bridge` driver. container_network_name and container_network_mode are mutually exclusive,  the name takes precedence.

For podman we have to check if the network exists first, because the command is not idempotent. The configuration is slightly different, see https://docs.ansible.com/ansible/latest/collections/containers/podman/podman_container_module.html#parameter-network.