### PR TITLE
Fix go_host_to_map lookup when ansible_host is FQDN/IP

### DIFF
--- a/roles/go/defaults/main.yaml
+++ b/roles/go/defaults/main.yaml
@@ -20,7 +20,7 @@ go_install_dir: "/usr/local"
 # Enable CGO for cross-compilation (requires a C compiler)
 go_cgo_enabled: false
 # Host to map platform from (used by map_platform task)
-go_host_to_map: "{{ ansible_host }}"
+go_host_to_map: "{{ inventory_hostname }}"
 # Mapped GOOS value (set by map_platform task)
 go_os: ""
 # Mapped GOARCH value (set by map_platform task)


### PR DESCRIPTION
## Summary
- Default `go_host_to_map` to `inventory_hostname`

## Why
`hostvars` is keyed by inventory hostname. When `go_host_to_map` was set to `ansible_host` (often FQDN/IP), `hostvars[go_host_to_map]` failed. This change keeps lookups consistent and prevents crashes in multi-host inventories.