### PR TITLE
Adding subjectKeyIdentifier in openssl template

### DIFF
--- a/roles/openssl/templates/sections/v3_req.yaml.j2
+++ b/roles/openssl/templates/sections/v3_req.yaml.j2
@@ -16,3 +16,4 @@ keyUsage = {{ openssl_key_usage }}
 # Extended key usage refines purpose: server/client authentication, code signing, etc.
 # For TLS, "serverAuth" and "clientAuth" are typical.
 extendedKeyUsage = {{ openssl_extended_key_usage }}
+subjectKeyIdentifier = hash

--- a/roles/openssl/templates/sections/v3_req.yaml.j2
+++ b/roles/openssl/templates/sections/v3_req.yaml.j2
@@ -16,4 +16,5 @@ keyUsage = {{ openssl_key_usage }}
 # Extended key usage refines purpose: server/client authentication, code signing, etc.
 # For TLS, "serverAuth" and "clientAuth" are typical.
 extendedKeyUsage = {{ openssl_extended_key_usage }}
+# Required by Hyperledger Fabric MSP: adds Subject Key Identifier (SKI) to CA cert
 subjectKeyIdentifier = hash


### PR DESCRIPTION
Adding subjectKeyIdentifier in openssl template to resolve certificate generation misconfiguration in my Redhat local machine.