### PR TITLE
Fixed the YAML body mapping for limit rate

### DIFF
--- a/roles/loadgen/tasks/limit_rate.yaml
+++ b/roles/loadgen/tasks/limit_rate.yaml
@@ -19,10 +19,6 @@
     validate_certs: false
     method: POST
     body_format: json
-    body: >-
-      {{
-        {
-          'rate': loadgen_limit_rate | int
-        }
-      }}
+    body:
+      rate: "{{ loadgen_limit_rate | int }}"
     status_code: 200


### PR DESCRIPTION
The API rejected the malformed body so after the fix, it is a success now.
Fixes #362